### PR TITLE
Removed -y option for add-apt-repository

### DIFF
--- a/sc-proxy/install-node-and-mongo-on-ubuntu.bash
+++ b/sc-proxy/install-node-and-mongo-on-ubuntu.bash
@@ -21,7 +21,7 @@ echo "Installing requirements for building node extensions" &&
 apt-get -y install build-essential &&
 echo "Installing Node" &&
 apt-get -y install python-software-properties &&
-add-apt-repository -y ppa:chris-lea/node.js &&
+add-apt-repository ppa:chris-lea/node.js &&
 apt-get -y update &&
 apt-get -y install nodejs &&
 echo "Node installed" &&


### PR DESCRIPTION
The -y flag on add-apt-repository breaks the bash script with the following message:

Usage: add-apt-repository sourceline

add-apt-repository is a script for adding apt sources.list entries. 
It can be used to add any repository and also provides a shorthand 
synatax for Launchpad PPA (Personal Package Archive) repositories via
ppa:user/repository

add-apt-repository: error: no such option: -y
