### PR TITLE
SSH_KEY_PATH optional settings variable added

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ This command will attempt to connect as root rather than the username found in `
 
 ## Changelog
 
+01/02/2017:
+
+* `SSH_KEY_PATH` optional variable added to **development** `settings` to use the separate (e.g. passwordless) SSH private key for authentication with the server.
+
 12/23/2016:
 
 * `sc-restart` is now available as a handy remote command. It runs the `deployment/stop` and `deployment/start` scripts on the specified target server, exactly as if you had redeployed the site.

--- a/bin/sc-deploy
+++ b/bin/sc-deploy
@@ -24,6 +24,10 @@ fi
 source deployment/settings || exit 1
 source deployment/settings.$TARGET || exit 1
 
+if [ -n "$SSH_KEY_PATH" ]; then
+  SSH_KEY="-i $SSH_KEY_PATH"
+fi
+
 VERSION=`date "+%Y-%m-%d-%H-%M-%S"`
 
 # rsync to a new folder, then flip the symlink if everything runs without error.
@@ -53,9 +57,9 @@ fi
 # an 'if folder exists' test on the server; make the remote script a multiline,
 # maintainable thing
 
-ssh -p $SSH_PORT $USER@$SERVER "mkdir -p $DIR/deployments" &&
-rsync -e "ssh -p $SSH_PORT -l$USER" -C -a --delete $EXCLUDE . $USER@$SERVER:$DEPLOYTO &&
-ssh -p $SSH_PORT $USER@$SERVER <<EOM
+ssh -p $SSH_PORT $SSH_KEY $USER@$SERVER "mkdir -p $DIR/deployments" &&
+rsync -e "ssh -p $SSH_PORT $SSH_KEY -l$USER" -C -a --delete $EXCLUDE . $USER@$SERVER:$DEPLOYTO &&
+ssh -p $SSH_PORT $SSH_KEY $USER@$SERVER <<EOM
   $ADJUST_PATH
   # A good place to run "npm install"
   echo "Looking for dependencies script at $DEPLOYTO/deployment/dependencies"

--- a/bin/sc-disable
+++ b/bin/sc-disable
@@ -22,7 +22,11 @@ TARGET=$1
 source deployment/settings || exit 1
 source deployment/settings.$TARGET || exit 1
 
-ssh -p $SSH_PORT $USER@$SERVER <<EOM
+if [ -n "$SSH_KEY_PATH" ]; then
+  SSH_KEY="-i $SSH_KEY_PATH"
+fi
+
+ssh -p $SSH_PORT $SSH_KEY $USER@$SERVER <<EOM
 cd $DIR/current || exit 1
 bash deployment/stop &&
 cd $DIR &&

--- a/bin/sc-enable
+++ b/bin/sc-enable
@@ -24,7 +24,11 @@ TARGET=$1
 source deployment/settings || exit 1
 source deployment/settings.$TARGET || exit 1
 
-ssh -p $SSH_PORT $USER@$SERVER <<EOM
+if [ -n "$SSH_KEY_PATH" ]; then
+  SSH_KEY="-i $SSH_KEY_PATH"
+fi
+
+ssh -p $SSH_PORT $SSH_KEY $USER@$SERVER <<EOM
 cd /opt/stagecoach &&
 mv disabled-apps/$PROJECT $DIR &&
 cd $DIR/current &&

--- a/bin/sc-restart
+++ b/bin/sc-restart
@@ -18,7 +18,11 @@ TARGET=$1
 source deployment/settings || exit 1
 source deployment/settings.$TARGET || exit 1
 
-ssh -p $SSH_PORT $USER@$SERVER <<EOM
+if [ -n "$SSH_KEY_PATH" ]; then
+  SSH_KEY="-i $SSH_KEY_PATH"
+fi
+
+ssh -p $SSH_PORT $SSH_KEY $USER@$SERVER <<EOM
 cd $DIR/current &&
 bash deployment/stop &&
 bash deployment/start &&

--- a/bin/sc-rollback
+++ b/bin/sc-rollback
@@ -24,13 +24,17 @@ source deployment/settings.$TARGET || exit 1
 
 DEPLOYMENTS="$DIR/deployments"
 
+if [ -n "$SSH_KEY_PATH" ]; then
+  SSH_KEY="-i $SSH_KEY_PATH"
+fi
+
 if [ -z "$2" ] ; then
   echo "Available deployments:"
-  ssh -p $SSH_PORT $USER@$SERVER ls $DEPLOYMENTS
+  ssh -p $SSH_PORT $SSH_KEY $USER@$SERVER ls $DEPLOYMENTS
   exit 0
 fi
 
-ssh -p $SSH_PORT $USER@$SERVER <<EOM
+ssh -p $SSH_PORT $SSH_KEY $USER@$SERVER <<EOM
 cd $DIR/current &&
 sh deployment/stop &&
 cd $DIR &&

--- a/bin/sc-shell
+++ b/bin/sc-shell
@@ -37,9 +37,13 @@ if [ -z "$MY_USER" ]; then
   MY_USER=$USER
 fi
 
+if [ -n "$SSH_KEY_PATH" ]; then
+  SSH_KEY="-i $SSH_KEY_PATH"
+fi
+
 if [ -z "$2" ] ; then
-  ssh -t -p $SSH_PORT $MY_USER@$SERVER "cd $DIR/current && bash"
+  ssh -t -p $SSH_PORT $SSH_KEY $MY_USER@$SERVER "cd $DIR/current && bash"
 else
-  ssh -p $SSH_PORT $MY_USER@$SERVER "cd $DIR/current && ${@:2}"
+  ssh -p $SSH_PORT $SSH_KEY $MY_USER@$SERVER "cd $DIR/current && ${@:2}"
 fi
 


### PR DESCRIPTION
If the main SSH private key has a passphrase, then it's quite annoying to enter the password three times during the deployment. So I added the ability to use a special (passwordless/passphraseless) key only for Stagecoach deployments an its other commands.