### PR TITLE
Pass the TARGET to the before-connecting script as %1

### DIFF
--- a/bin/sc-deploy
+++ b/bin/sc-deploy
@@ -45,7 +45,7 @@ KEPT=$[$KEEP+1]
 
 if [ -f "deployment/before-connecting" ]; then
   # A good place to run "gulp" etc.
-  bash deployment/before-connecting
+  bash deployment/before-connecting $TARGET
 fi
 
 # For now we just don't check whether 'stop' worked, because it fails on the first


### PR DESCRIPTION
My 'before-connecting' script needs to perform some actions that are different for each of the deployment targets. I have simply added the $TARGET as a command-line argument so the script knows which target is being deployed.