### PR TITLE
fix bad settings example file breaking site restarts at reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ This isn't for Windows.
 
 ## Changelog
 
+06/11/2021:
+
+* The `/opt/stagecoach/settings.example` file contained incorrect settings. As written, it would result in `/opt/stagecoach/bin/sc-start-all` failing to restart applications at reboot. It now contains appropriate settings for the top-level configuration file. If you copied this file, edit it to match the new `settings.example`, possibly changing the non-root username setting to match your needs.
+
 08/21/2020:
 
 * There was an undocumented, unofficial feature to `sudo` on the server side after making the `ssh` connection, set by passing the `SUDO_USER` environment variable. As it turns out, this was a bad idea because `SUDO_USER` is automatically set if you have used sudo in your *local* environment. We have changed the variable `stagecoach` supports to `REMOTE_SUDO_USER` and documented the feature.

--- a/settings.example
+++ b/settings.example
@@ -1,10 +1,9 @@
-# Should be the same as the shortname / repo name / database name /
-# everything name of your Apostrophe site
-PROJECT=foo
+# Example of the top-level /opt/stagecoach/settings file.
+
 # Currently this is the only allowable value
-DIR=/opt/stagecoach/apps/$PROJECT
-# Occasionally, this is changed in a misguided attempt at security by obscurity
-SSH_PORT=22
+DIR=/opt/stagecoach
+
+
 # User to launch individual webapps as.
-# Since they do not listen on port 80 this need not be root
+# Since they do not listen on port 80 this should not be root
 USER=nodeapps


### PR DESCRIPTION
This is pretty cut and dried: "DIR" needs to be /opt/stagecoach, and it was something else project-specific that didn't belong at this level at all. I'll have to hunt down servers that contain this goof and update them so they can bring back stagecoach sites at reboot.